### PR TITLE
State enum implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,5 @@ These things have been implemented so far:
 | `playnoise_exclusive` | Plays white noise in exclusive mode on the default output device. Shows how to handle HRESULT errors.  |
 | `loopback`            | Shows how to simultaneously capture and render sound, with separate threads for capture and render.    |
 | `record`              | Records audio from the default device, and saves the raw samples to a file.                            |
+| `devices`             | Lists all available audio devices and displays the default devices.                                    |
 

--- a/examples/devices.rs
+++ b/examples/devices.rs
@@ -7,7 +7,11 @@ fn main() {
     for device in &DeviceCollection::new(&Direction::Render).unwrap() {
         let dev = device.unwrap();
         let state = &dev.get_state().unwrap();
-        println!("Device: {:?}. State: {:?}", &dev.get_friendlyname().unwrap(), state);
+        println!(
+            "Device: {:?}. State: {:?}",
+            &dev.get_friendlyname().unwrap(),
+            state
+        );
     }
 
     println!("Default output devices:");

--- a/examples/devices.rs
+++ b/examples/devices.rs
@@ -5,8 +5,9 @@ fn main() {
 
     println!("Found the following output devices:");
     for device in &DeviceCollection::new(&Direction::Render).unwrap() {
-        let state = &device.unwrap().get_state_enum().unwrap();
-        println!("Device: {:?}. State: {:?}", device.unwrap().get_friendlyname().unwrap(), state);
+        let dev = device.unwrap();
+        let state = &dev.get_state().unwrap();
+        println!("Device: {:?}. State: {:?}", &dev.get_friendlyname().unwrap(), state);
     }
 
     println!("Default output devices:");

--- a/examples/devices.rs
+++ b/examples/devices.rs
@@ -5,7 +5,8 @@ fn main() {
 
     println!("Found the following output devices:");
     for device in &DeviceCollection::new(&Direction::Render).unwrap() {
-        println!("Device: {:?}", device.unwrap().get_friendlyname().unwrap());
+        let state = &device.unwrap().get_state_enum().unwrap();
+        println!("Device: {:?}. State: {:?}", device.unwrap().get_friendlyname().unwrap(), state);
     }
 
     println!("Default output devices:");

--- a/src/api.rs
+++ b/src/api.rs
@@ -161,6 +161,53 @@ impl fmt::Display for SessionState {
         }
     }
 }
+
+/// States of an Device, for more information see Wasapi documentation
+/// https://learn.microsoft.com/en-us/windows/win32/coreaudio/device-state-xxx-constants
+#[derive(Debug, Eq, PartialEq)]
+pub enum DeviceState {
+    /// The audio endpoint device is active. That is, the audio adapter that connects to the
+    /// endpoint device is present and enabled. In addition, if the endpoint device plugs int
+    /// a jack on the adapter, then the endpoint device is plugged in.
+    Active,
+    /// The audio endpoint device is disabled. The user has disabled the device in the Windows
+    /// multimedia control panel, Mmsys.cpl
+    Disabled,
+    /// The audio endpoint device is not present because the audio adapter that connects to the
+    /// endpoint device has been removed from the system, or the user has disabled the adapter
+    /// device in Device Manager.
+    NotPresent,
+    /// The audio endpoint device is unplugged. The audio adapter that contains the jack for the
+    /// endpoint device is present and enabled, but the endpoint device is not plugged into the
+    /// jack. Only a device with jack-presence detection can be in this state.
+    Unplugged,
+}
+
+impl fmt::Display for DeviceState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            DeviceState::Active => write!(f, "Active"),
+            DeviceState::Disabled => write!(f, "Disabled"),
+            DeviceState::NotPresent => write!(f, "NotPresent"),
+            DeviceState::Unplugged => write!(f, "Unplugged"),
+        }
+    }
+}
+
+impl TryFrom<u32> for DeviceState {
+    type Error = ();
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(DeviceState::Active),
+            2 => Ok(DeviceState::Disabled),
+            4 => Ok(DeviceState::NotPresent),
+            8 => Ok(DeviceState::Unplugged),
+            _ => {Err(()) }
+        }
+    }
+}
+
 /// Get the default playback or capture device for the console role
 pub fn get_default_device(direction: &Direction) -> WasapiRes<Device> {
     get_default_device_for_role(direction, &Role::Console)
@@ -309,6 +356,16 @@ impl Device {
         let state: u32 = unsafe { self.device.GetState()? };
         trace!("state: {:?}", state);
         Ok(state)
+    }
+
+    /// Read state from an IMMDevice and return enum
+    pub fn get_state_enum(&self) -> WasapiRes<DeviceState> {
+        let state: u32 = unsafe { self.device.GetState()? };
+        trace!("state: {:?}", state);
+        match state.try_into() {
+            Ok(state) => Ok(state),
+            Err(_) => Err(WasapiError::new("Unable to convert state").into()),
+        }
     }
 
     /// Read the friendly name of the endpoint device (for example, "Speakers (XYZ Audio Adapter)")

--- a/src/api.rs
+++ b/src/api.rs
@@ -20,7 +20,8 @@ use windows::{
         AUDCLNT_BUFFERFLAGS_TIMESTAMP_ERROR, AUDCLNT_SHAREMODE_EXCLUSIVE, AUDCLNT_SHAREMODE_SHARED,
         AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM, AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
         AUDCLNT_STREAMFLAGS_LOOPBACK, AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY, DEVICE_STATE_ACTIVE,
-        WAVEFORMATEX, WAVEFORMATEXTENSIBLE,
+        DEVICE_STATE_DISABLED, DEVICE_STATE_NOTPRESENT, DEVICE_STATE_UNPLUGGED, WAVEFORMATEX,
+        WAVEFORMATEXTENSIBLE,
     },
     Win32::Media::KernelStreaming::WAVE_FORMAT_EXTENSIBLE,
     Win32::System::Com::STGM_READ,
@@ -341,11 +342,10 @@ impl Device {
         let state: u32 = unsafe { self.device.GetState()? };
         trace!("state: {:?}", state);
         let state_enum = match state {
-            // Explicit path used to prevent import changes treating constants as variables
-            windows::Win32::Media::Audio::DEVICE_STATE_ACTIVE => DeviceState::Active,
-            windows::Win32::Media::Audio::DEVICE_STATE_DISABLED => DeviceState::Disabled,
-            windows::Win32::Media::Audio::DEVICE_STATE_NOTPRESENT => DeviceState::NotPresent,
-            windows::Win32::Media::Audio::DEVICE_STATE_UNPLUGGED => DeviceState::Unplugged,
+            DEVICE_STATE_ACTIVE => DeviceState::Active,
+            DEVICE_STATE_DISABLED => DeviceState::Disabled,
+            DEVICE_STATE_NOTPRESENT => DeviceState::NotPresent,
+            DEVICE_STATE_UNPLUGGED => DeviceState::Unplugged,
             _ => return Err(WasapiError::new(&format!("Got an illegal state: {}", state)).into()),
         };
         Ok(state_enum)

--- a/src/api.rs
+++ b/src/api.rs
@@ -356,8 +356,7 @@ impl Device {
         trace!("state: {:?}", state);
         match state.try_into() {
             Ok(state) => Ok(state),
-            //Err(e) => Err(Box::try_from(e).unwrap()),
-            x => Ok(x?),
+            Err(e) => Err(Box::new(e)),
         }
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -93,8 +93,8 @@ impl fmt::Display for Direction {
     }
 }
 
-/// Role for audio device. Console is the role used by most applications
-/// https://learn.microsoft.com/en-us/windows/win32/api/mmdeviceapi/ne-mmdeviceapi-eroleV
+/// Wrapper for [ERole](https://learn.microsoft.com/en-us/windows/win32/api/mmdeviceapi/ne-mmdeviceapi-erole).
+/// Console is the role used by most applications
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Role {
     Console,
@@ -162,8 +162,7 @@ impl fmt::Display for SessionState {
     }
 }
 
-/// States of an Device, for more information see Wasapi documentation
-/// https://learn.microsoft.com/en-us/windows/win32/coreaudio/device-state-xxx-constants
+/// Enum wrapping [DEVICE_STATE_XXX](https://learn.microsoft.com/en-us/windows/win32/coreaudio/device-state-xxx-constants)
 #[derive(Debug, Eq, PartialEq)]
 pub enum DeviceState {
     /// The audio endpoint device is active. That is, the audio adapter that connects to the
@@ -357,7 +356,8 @@ impl Device {
         trace!("state: {:?}", state);
         match state.try_into() {
             Ok(state) => Ok(state),
-            Err(_) => Err(WasapiError::new("Unable to convert state").into()),
+            //Err(e) => Err(Box::try_from(e).unwrap()),
+            x => Ok(x?),
         }
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -342,11 +342,11 @@ impl Device {
         let state: u32 = unsafe { self.device.GetState()? };
         trace!("state: {:?}", state);
         let state_enum = match state {
-            DEVICE_STATE_ACTIVE => DeviceState::Active,
-            DEVICE_STATE_DISABLED => DeviceState::Disabled,
-            DEVICE_STATE_NOTPRESENT => DeviceState::NotPresent,
-            DEVICE_STATE_UNPLUGGED => DeviceState::Unplugged,
-            _ => return Err(WasapiError::new(&format!("Got an illegal state: {}", state)).into()),
+            _ if state == DEVICE_STATE_ACTIVE => DeviceState::Active,
+            _ if state == DEVICE_STATE_DISABLED => DeviceState::Disabled,
+            _ if state == DEVICE_STATE_NOTPRESENT => DeviceState::NotPresent,
+            _ if state == DEVICE_STATE_UNPLUGGED => DeviceState::Unplugged,
+            x => return Err(WasapiError::new(&format!("Got an illegal state: {}", x)).into()),
         };
         Ok(state_enum)
     }
@@ -758,9 +758,9 @@ impl AudioSessionControl {
         let state = unsafe { self.control.GetState()? };
         #[allow(non_upper_case_globals)]
         let sessionstate = match state {
-            AudioSessionStateActive => SessionState::Active,
-            AudioSessionStateInactive => SessionState::Inactive,
-            AudioSessionStateExpired => SessionState::Expired,
+            _ if state == AudioSessionStateActive => SessionState::Active,
+            _ if state == AudioSessionStateInactive => SessionState::Inactive,
+            _ if state == AudioSessionStateExpired => SessionState::Expired,
             x => {
                 return Err(
                     WasapiError::new(&format!("Got an illegal session state {:?}", x)).into(),

--- a/src/api.rs
+++ b/src/api.rs
@@ -195,7 +195,7 @@ impl fmt::Display for DeviceState {
 }
 
 impl TryFrom<u32> for DeviceState {
-    type Error = ();
+    type Error = WasapiError;
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         match value {
@@ -203,7 +203,7 @@ impl TryFrom<u32> for DeviceState {
             2 => Ok(DeviceState::Disabled),
             4 => Ok(DeviceState::NotPresent),
             8 => Ok(DeviceState::Unplugged),
-            _ => {Err(()) }
+            x => Err(WasapiError::new(format!("Unrecognised value: {}", x).as_str()).into())
         }
     }
 }
@@ -352,14 +352,7 @@ impl Device {
     }
 
     /// Read state from an IMMDevice
-    pub fn get_state(&self) -> WasapiRes<u32> {
-        let state: u32 = unsafe { self.device.GetState()? };
-        trace!("state: {:?}", state);
-        Ok(state)
-    }
-
-    /// Read state from an IMMDevice and return enum
-    pub fn get_state_enum(&self) -> WasapiRes<DeviceState> {
+    pub fn get_state(&self) -> WasapiRes<DeviceState> {
         let state: u32 = unsafe { self.device.GetState()? };
         trace!("state: {:?}", state);
         match state.try_into() {


### PR DESCRIPTION
Hello,

Not a formal PR yet, just to get an idea of your thoughts. `get_state` currently returns `u32`, leaving the user to unpack it. It would follow the pattern of the package better to return an enum. If you agree, the two approaches I can see are:
1. Break backwards compatiblity and update the return type of `get_state`
2. Add a new method
3. 1.0 and use the major version bump to excuse the break

In general, I would favour keeping backwards compat, but a [rudimentary search](https://github.com/search?q=wasapi+get_state+language%3ARust&type=code&l=Rust) can only find [one](https://github.com/Fredemus/rainout/blob/c084cb202020d1e5f0eb8ce2c68959f07b24d942/src/wasapi_backend/enumeration.rs#L304) place in public repos where the method is used. This could be used as an excuse to just "fix" it as is without a version bump.

Do you have any thoughts?

Max