### PR TITLE
Some usability improvements!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ widestring = "1.0.2"
 log = "0.4.18"
 num-integer = "0.1"
 windows-core = "0.57"
+thiserror = "1.0.65"
 
 [dev-dependencies]
 simplelog = "0.12.1"

--- a/examples/playnoise_exclusive.rs
+++ b/examples/playnoise_exclusive.rs
@@ -4,7 +4,6 @@ use wasapi::*;
 #[macro_use]
 extern crate log;
 use simplelog::*;
-use windows::core::Error;
 
 // A selection of the possible errors
 use windows::Win32::Foundation::E_INVALIDARG;
@@ -62,7 +61,7 @@ fn main() {
     match init_result {
         Ok(()) => debug!("IAudioClient::Initialize ok"),
         Err(e) => {
-            if let Some(werr) = e.downcast_ref::<Error>() {
+            if let WasapiError::Windows(werr) = e {
                 // Some of the possible errors. See the documentation for the full list and descriptions.
                 // https://docs.microsoft.com/en-us/windows/win32/api/audioclient/nf-audioclient-iaudioclient-initialize
                 match werr.code() {

--- a/src/api.rs
+++ b/src/api.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 use std::pin::Pin;
 use std::rc::Weak;
 use std::sync::{Arc, Condvar, Mutex};
-use std::{error, fmt, ptr, slice};
+use std::{fmt, ptr, slice};
 use widestring::U16CString;
 use windows::Win32::Media::Audio::{
     ActivateAudioInterfaceAsync, EDataFlow, ERole, IActivateAudioInterfaceAsyncOperation,
@@ -47,35 +47,9 @@ use windows::{
 };
 use windows_core::{implement, IUnknown, Interface, PROPVARIANT};
 
-use crate::{make_channelmasks, AudioSessionEvents, EventCallbacks, WaveFormat};
+use crate::{make_channelmasks, AudioSessionEvents, EventCallbacks, WasapiError, WaveFormat};
 
-pub(crate) type WasapiRes<T> = Result<T, Box<dyn error::Error>>;
-
-/// Error returned by the Wasapi crate.
-#[derive(Debug)]
-pub struct WasapiError {
-    desc: String,
-}
-
-impl fmt::Display for WasapiError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.desc)
-    }
-}
-
-impl error::Error for WasapiError {
-    fn description(&self) -> &str {
-        &self.desc
-    }
-}
-
-impl WasapiError {
-    pub fn new(desc: &str) -> Self {
-        WasapiError {
-            desc: desc.to_owned(),
-        }
-    }
-}
+pub(crate) type WasapiRes<T> = Result<T, WasapiError>;
 
 /// Initializes COM for use by the calling thread for the multi-threaded apartment (MTA).
 pub fn initialize_mta() -> HRESULT {
@@ -353,7 +327,7 @@ impl DeviceCollection {
                 return Ok(device);
             }
         }
-        Err(WasapiError::new(format!("Unable to find device {}", name).as_str()).into())
+        Err(WasapiError::DeviceNotFound(name.to_owned()))
     }
 
     /// Get the direction for this [DeviceCollection]
@@ -428,11 +402,7 @@ impl Device {
             _ if pdwstate == DEVICE_STATE_DISABLED.0 => DeviceState::Disabled,
             _ if pdwstate == DEVICE_STATE_NOTPRESENT.0 => DeviceState::NotPresent,
             _ if pdwstate == DEVICE_STATE_UNPLUGGED.0 => DeviceState::Unplugged,
-            x => {
-                return Err(
-                    WasapiError::new(&format!("Got an illegal state: DEVICE_STATE({})", x)).into(),
-                )
-            }
+            x => return Err(WasapiError::IllegalDeviceState(x)),
         };
         Ok(state_enum)
     }
@@ -764,7 +734,7 @@ impl AudioClient {
                 return Ok(wave_fmt);
             }
         }
-        Err(WasapiError::new("Unable to find a supported format").into())
+        Err(WasapiError::UnsupportedFormat)
     }
 
     /// Get default and minimum periods in 100-nanosecond units
@@ -831,19 +801,17 @@ impl AudioClient {
         convert: bool,
     ) -> WasapiRes<()> {
         if sharemode == &ShareMode::Exclusive && convert {
-            return Err(
-                WasapiError::new("Cant use automatic format conversion in exclusive mode").into(),
-            );
+            return Err(WasapiError::AutomaticFormatConversionInExclusiveMode);
         }
         let mut streamflags = match (&self.direction, direction, sharemode) {
             (Direction::Render, Direction::Capture, ShareMode::Shared) => {
                 AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_LOOPBACK
             }
             (Direction::Render, Direction::Capture, ShareMode::Exclusive) => {
-                return Err(WasapiError::new("Cant use Loopback with exclusive mode").into());
+                return Err(WasapiError::LoopbackWithExclusiveMode);
             }
             (Direction::Capture, Direction::Render, _) => {
-                return Err(WasapiError::new("Cant render to a capture device").into());
+                return Err(WasapiError::RenderToCaptureDevice);
             }
             _ => AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
         };
@@ -911,7 +879,7 @@ impl AudioClient {
 
                 buffer_frame_count - padding_count
             }
-            _ => return Err(WasapiError::new("Client has not been initialized").into()),
+            _ => return Err(WasapiError::ClientNotInit),
         };
         Ok(frames)
     }
@@ -991,11 +959,7 @@ impl AudioSessionControl {
             _ if state == AudioSessionStateActive => SessionState::Active,
             _ if state == AudioSessionStateInactive => SessionState::Inactive,
             _ if state == AudioSessionStateExpired => SessionState::Expired,
-            x => {
-                return Err(
-                    WasapiError::new(&format!("Got an illegal session state {:?}", x)).into(),
-                );
-            }
+            x => return Err(WasapiError::IllegalSessionState(x.0)),
         };
         Ok(sessionstate)
     }
@@ -1006,9 +970,7 @@ impl AudioSessionControl {
 
         match unsafe { self.control.RegisterAudioSessionNotification(&events) } {
             Ok(()) => Ok(()),
-            Err(err) => {
-                Err(WasapiError::new(&format!("Failed to register notifications, {}", err)).into())
-            }
+            Err(err) => Err(WasapiError::RegisterNotifications(err)),
         }
     }
 }
@@ -1060,15 +1022,7 @@ impl AudioRenderClient {
         }
         let nbr_bytes = nbr_frames * self.bytes_per_frame;
         if nbr_bytes != data.len() {
-            return Err(WasapiError::new(
-                format!(
-                    "Wrong length of data, got {}, expected {}",
-                    data.len(),
-                    nbr_bytes
-                )
-                .as_str(),
-            )
-            .into());
+            return Err(WasapiError::InvalidDataLength(data.len(), nbr_bytes));
         }
         let bufferptr = unsafe { self.client.GetBuffer(nbr_frames as u32)? };
         let bufferslice = unsafe { slice::from_raw_parts_mut(bufferptr, nbr_bytes) };
@@ -1097,10 +1051,7 @@ impl AudioRenderClient {
         }
         let nbr_bytes = nbr_frames * self.bytes_per_frame;
         if nbr_bytes > data.len() {
-            return Err(WasapiError::new(
-                format!("To little data, got {}, need {}", data.len(), nbr_bytes).as_str(),
-            )
-            .into());
+            return Err(WasapiError::InvalidDataLength(data.len(), nbr_bytes));
         }
         let bufferptr = unsafe { self.client.GetBuffer(nbr_frames as u32)? };
         let bufferslice = unsafe { slice::from_raw_parts_mut(bufferptr, nbr_bytes) };
@@ -1208,14 +1159,10 @@ impl AudioCaptureClient {
         }
         if data_len_in_frames < nbr_frames_returned as usize {
             unsafe { self.client.ReleaseBuffer(nbr_frames_returned)? };
-            return Err(WasapiError::new(
-                format!(
-                    "Wrong length of data, got {} frames, expected at least {} frames",
-                    data_len_in_frames, nbr_frames_returned
-                )
-                .as_str(),
-            )
-            .into());
+            return Err(WasapiError::InvalidDataLength(
+                data_len_in_frames,
+                nbr_frames_returned as usize,
+            ));
         }
         let len_in_bytes = nbr_frames_returned as usize * self.bytes_per_frame;
         let bufferslice = unsafe { slice::from_raw_parts(buffer_ptr, len_in_bytes) };
@@ -1276,7 +1223,7 @@ impl Handle {
     pub fn wait_for_event(&self, timeout_ms: u32) -> WasapiRes<()> {
         let retval = unsafe { WaitForSingleObject(self.handle, timeout_ms) };
         if retval.0 != WAIT_OBJECT_0.0 {
-            return Err(WasapiError::new("Wait timed out").into());
+            return Err(WasapiError::EventTimeout);
         }
         Ok(())
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,33 @@
+#[derive(Debug, thiserror::Error)]
+pub enum WasapiError {
+    #[error("Unable to find device with name: {0}")]
+    DeviceNotFound(String),
+    #[error("Got an illegal device state: {0}")]
+    IllegalDeviceState(u32),
+    #[error("Got an illegal device role: {0}")]
+    IllegalDeviceRole(i32),
+    #[error("Got an illegal device direction: {0}")]
+    IllegalDeviceDirection(i32),
+    #[error("Got an illegal session state: {0}")]
+    IllegalSessionState(i32),
+    #[error("Could not find a compatible format")]
+    UnsupportedFormat,
+    #[error("Got an unknown Subformat: {0:?}")]
+    UnsupportedSubformat(windows_core::GUID),
+    #[error("Client has not been initialized")]
+    ClientNotInit,
+    #[error("Couldn't register session notifications: {0}")]
+    RegisterNotifications(windows_core::Error),
+    #[error("Wrong length of data, got {0} frames, expected at least {1} frames")]
+    InvalidDataLength(usize, usize),
+    #[error("Handle wait timed out")]
+    EventTimeout,
+    #[error("Cant use automatic format conversion in exclusive mode")]
+    AutomaticFormatConversionInExclusiveMode,
+    #[error("Cant use Loopback with exclusive mode")]
+    LoopbackWithExclusiveMode,
+    #[error("Cant render to a capture device")]
+    RenderToCaptureDevice,
+    #[error("Windows returned an error: {0}")]
+    Windows(#[from] windows_core::Error),
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,8 +18,10 @@ pub enum WasapiError {
     ClientNotInit,
     #[error("Couldn't register session notifications: {0}")]
     RegisterNotifications(windows_core::Error),
-    #[error("Wrong length of data, got {0} frames, expected at least {1} frames")]
-    InvalidDataLength(usize, usize),
+    #[error("Wrong length of data, got {received}, expected exactly {expected}")]
+    DataLengthMismatch { received: usize, expected: usize },
+    #[error("Wrong length of data, got {received}, expected at least {expected}")]
+    DataLengthTooShort { received: usize, expected: usize },
     #[error("Handle wait timed out")]
     EventTimeout,
     #[error("Cant use automatic format conversion in exclusive mode")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,11 @@
 //! | `record_application`  | Records audio from a single application, and saves the raw samples to a file.                          |
 
 mod api;
+mod errors;
 mod events;
 mod waveformat;
 pub use api::*;
+pub use errors::*;
 pub use events::*;
 pub use waveformat::*;
 pub use windows::core::GUID;

--- a/src/waveformat.rs
+++ b/src/waveformat.rs
@@ -152,9 +152,7 @@ impl WaveFormat {
         let sample_type = match formattag as u32 {
             WAVE_FORMAT_PCM => SampleType::Int,
             WAVE_FORMAT_IEEE_FLOAT => SampleType::Float,
-            _ => {
-                return Err(WasapiError::new("Unsupported format").into());
-            }
+            _ => return Err(WasapiError::UnsupportedFormat),
         };
         let storebits = 8 * blockalign / channels;
         Ok(WaveFormat::new(
@@ -177,9 +175,7 @@ impl WaveFormat {
         let sample_type = match self.wave_fmt.SubFormat {
             KSDATAFORMAT_SUBTYPE_IEEE_FLOAT => WAVE_FORMAT_IEEE_FLOAT,
             KSDATAFORMAT_SUBTYPE_PCM => WAVE_FORMAT_PCM,
-            _ => {
-                return Err(WasapiError::new("Unsupported format").into());
-            }
+            _ => return Err(WasapiError::UnsupportedFormat),
         };
         let wave_format = WAVEFORMATEX {
             cbSize: 0,
@@ -249,12 +245,7 @@ impl WaveFormat {
         let subfmt = match self.wave_fmt.SubFormat {
             KSDATAFORMAT_SUBTYPE_IEEE_FLOAT => SampleType::Float,
             KSDATAFORMAT_SUBTYPE_PCM => SampleType::Int,
-            _ => {
-                return Err(WasapiError::new(
-                    format!("Unknown subformat {:?}", { self.wave_fmt.SubFormat }).as_str(),
-                )
-                .into());
-            }
+            _ => return Err(WasapiError::UnsupportedSubformat(self.wave_fmt.SubFormat)),
         };
         Ok(subfmt)
     }


### PR DESCRIPTION
Howdy!

I've been working on a [binary crate](https://github.com/nullstalgia/redefaulter) using wasapi-rs, and I smoothed out some rough edges I ran into!

The first thing was implementing typed errors with `thiserror`, which also brings back `Send + 'static` to the error type (using `anyhow` with wasapi-rs wasn't pleasant at first) and simplifies away the need for `downcast_ref` in the `playnoise_exclusive` example.

Additionally since my crate required [dealing with both](https://github.com/nullstalgia/redefaulter/blob/5fa3da49783a78720f571779553a037f68b38750/src/platform/windows/device_notifications.rs#L116) `wasapi-rs` and `windows-rs` Role and Direction types, I added proper `From<>`s for those.

And lastly, I also would be [initializing my own](https://github.com/nullstalgia/redefaulter/blob/5fa3da49783a78720f571779553a037f68b38750/src/platform/windows/mod.rs#L244) `IMMDevice`s but wanted to continue to use the helper methods you had for your wrappers for them, so I added a public function to create a `Device`.

Feel free to let me know if you'd like any changes to the errors or alike!