### PR TITLE
Support more buffer info, exposing frame index and timestamp.

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1346,7 +1346,7 @@ pub struct BufferInfo {
     pub flags: BufferFlags,
     /// The index of the first frame that was read from the buffer.
     pub index: u64,
-    /// The timestamp of the first frame that was read from the buffer.
+    /// The timestamp in 100-nanosecond units of the first frame that was read from the buffer.
     pub timestamp: u64,
 }
 


### PR DESCRIPTION
Adds a `BufferInfo` struct so we can expose the index/timestamp of the frames read. This is important when syncing video/audio for instance.